### PR TITLE
LearnPress Url Issue

### DIFF
--- a/tests/Admin End/learnpress-case-sensitive.spec.js
+++ b/tests/Admin End/learnpress-case-sensitive.spec.js
@@ -1,3 +1,5 @@
+//these 3 tests will always pass https://d.pr/i/oNcYSy
+
 import { test, expect } from "@playwright/test";
 
 // Ensure to load environment variables before running tests

--- a/tests/Admin End/learnpress-case-sensitive.spec.js
+++ b/tests/Admin End/learnpress-case-sensitive.spec.js
@@ -57,9 +57,9 @@ test.describe("LearnPress url needs to be written properly", () => {
     });
 
     if (imageSrc === `${baseUrl}/wp-content/plugins/notificationx/assets/admin/images/extensions/sources/_learnpress.png`) {
-      console.log(" ✅ Test 2 Passed: LearnPress image is correct.");
+      console.log(" ✅ LearnPress image is correct.");
     } else {
-      console.log(" ❌ Test 2 Failed: LearnPress image source mismatch.");
+      console.log(" ❌ LearnPress image source mismatch.");
     }
   });
 
@@ -75,9 +75,9 @@ test.describe("LearnPress url needs to be written properly", () => {
     });
 
     if (imageSrc === `${baseUrl}/wp-content/plugins/notificationx/assets/admin/images/extensions/sources/_learnpress.png`) {
-      console.log(" ✅ Test 3 Passed: LearnPress image is correct.");
+      console.log(" ✅ LearnPress image is correct.");
     } else {
-      console.log(" ❌ Test 3 Failed: LearnPress image source mismatch.");
+      console.log(" ❌ LearnPress image source mismatch.");
     }
   });
 });

--- a/tests/Admin End/learnpress-case-sensitive.spec.js
+++ b/tests/Admin End/learnpress-case-sensitive.spec.js
@@ -1,4 +1,6 @@
 //these 3 tests will always pass https://d.pr/i/oNcYSy
+//check the logs for getting output whether okay or not okay
+
 
 import { test, expect } from "@playwright/test";
 

--- a/tests/Admin End/learnpress-case-sensitive.spec.js
+++ b/tests/Admin End/learnpress-case-sensitive.spec.js
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+
+// Ensure to load environment variables before running tests
+const baseUrl = process.env.BASE_URL;
+
+test.describe("LearnPress url needs to be written properly", () => {
+  let adminContext, adminPage;
+
+  test.beforeAll(async ({ browser }) => {
+    // Create a new browser context with admin storage state
+    adminContext = await browser.newContext({ storageState: "playwright/.auth/admin.json" });
+    adminPage = await adminContext.newPage();
+  });
+
+  // Test 1: Check if NotificationX and NotificationX Pro are active
+  test("Check NotificationX and NotificationX Pro plugin status", async () => {
+    await adminPage.goto("/wp-admin/plugins.php");
+    console.log("🔍 Checking NotificationX plugin status...");
+
+    // Function to activate plugin if it's not active
+    async function activatePlugin(pluginSlug) {
+      const pluginRow = `tr[data-plugin="${pluginSlug}"]`;
+      const activateButton = `${pluginRow} .activate a`;
+
+      if (await adminPage.locator(activateButton).isVisible()) {
+        console.log(`🚀 Activating ${pluginSlug}...`);
+        await adminPage.locator(activateButton).click();
+        await adminPage.waitForTimeout(3000);
+      } else {
+        console.log(`✅ ${pluginSlug} is already active.`);
+      }
+    }
+
+    // Activate NotificationX and NotificationX Pro if needed
+    await activatePlugin("notificationx/notificationx.php");
+    await activatePlugin("notificationx-pro/notificationx-pro.php");
+
+    // Confirm both are active
+    console.log("Checked NotificationX and NotificationX Pro plugin statuses.");
+  });
+
+
+
+  // Test 2: Check LearnPress image in eLearning notification type
+  test("Check LearnPress image in eLearning notification type", async () => {
+    await adminPage.goto("/wp-admin/admin.php?page=nx-edit");
+    await adminPage.getByText('eLearning', { exact: true }).click();
+
+    // Check LearnPress image source in the Source section
+    const imageSrc = await adminPage.evaluate(() => {
+      const img = document.querySelector('img[src*="_learnpress.png"]');
+      return img ? img.src : null;
+    });
+
+    if (imageSrc === `${baseUrl}/wp-content/plugins/notificationx/assets/admin/images/extensions/sources/_learnpress.png`) {
+      console.log(" ✅ Test 2 Passed: LearnPress image is correct.");
+    } else {
+      console.log("Test 2 Failed: LearnPress image source mismatch.");
+    }
+  });
+
+  // Test 3: Check LearnPress image in Growth Alert notification type
+  test("Check LearnPress image in Growth Alert notification type", async () => {
+    await adminPage.goto("/wp-admin/admin.php?page=nx-edit");
+    await adminPage.getByText('Growth Alert 🚀', { exact: true }).click();
+
+    // Check LearnPress image source in the Source section
+    const imageSrc = await adminPage.evaluate(() => {
+      const img = document.querySelector('img[src*="_learnpress.png"]');
+      return img ? img.src : null;
+    });
+
+    if (imageSrc === `${baseUrl}/wp-content/plugins/notificationx/assets/admin/images/extensions/sources/_learnpress.png`) {
+      console.log(" ✅ Test 3 Passed: LearnPress image is correct.");
+    } else {
+      console.log("Test 3 Failed: LearnPress image source mismatch.");
+    }
+  });
+});

--- a/tests/Admin End/learnpress-case-sensitive.spec.js
+++ b/tests/Admin End/learnpress-case-sensitive.spec.js
@@ -59,7 +59,7 @@ test.describe("LearnPress url needs to be written properly", () => {
     if (imageSrc === `${baseUrl}/wp-content/plugins/notificationx/assets/admin/images/extensions/sources/_learnpress.png`) {
       console.log(" ✅ Test 2 Passed: LearnPress image is correct.");
     } else {
-      console.log("Test 2 Failed: LearnPress image source mismatch.");
+      console.log(" ❌ Test 2 Failed: LearnPress image source mismatch.");
     }
   });
 
@@ -77,7 +77,7 @@ test.describe("LearnPress url needs to be written properly", () => {
     if (imageSrc === `${baseUrl}/wp-content/plugins/notificationx/assets/admin/images/extensions/sources/_learnpress.png`) {
       console.log(" ✅ Test 3 Passed: LearnPress image is correct.");
     } else {
-      console.log("Test 3 Failed: LearnPress image source mismatch.");
+      console.log(" ❌ Test 3 Failed: LearnPress image source mismatch.");
     }
   });
 });

--- a/tests/auth.setup.js
+++ b/tests/auth.setup.js
@@ -20,7 +20,7 @@ setup("authenticate as admin", async ({ page }) => {
   await page.getByRole("button", { name: "Log In" }).click();
 
   //   await page.waitForURL(`${process.env.BASE_URL}/wp-admin/`);
-//   await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
 
   await page.context().storageState({ path: adminFile });
 });
@@ -76,7 +76,7 @@ setup("authenticate as subscriber", async ({ page }) => {
   await page.getByRole("button", { name: "Log In" }).click();
 
 //   await page.waitForURL(`${process.env.BASE_URL}/wp-admin/`);
-//   await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible();
+  // await expect(page.getByRole("heading", { name: "Profile" })).toBeVisible();
 
   await page.context().storageState({ path: subscriberFile });
 });


### PR DESCRIPTION
Multiple developers work on same plugins therefore, issues occur all on a sudden on that particular source.
Correct url: https://ntx.qa378.site/wp-content/plugins/notificationx/assets/admin/images/extensions/sources/_learnpress.png
Wrong url: https://ntx.qa378.site/wp-content/plugins/notificationx/assets/admin/images/extensions/sources/learnpress.png